### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ Because this is the first time I have tried to create a Stata package (or worked
 There are two dependencies that must be installed first 
 
  ```
-ssc install moremata bspline
-net from https://raw.githubusercontent.com/paulbousquet/SmoothLP/master 
+ssc install moremata
+ssc install bspline
+net install slp_irf, from(https://raw.githubusercontent.com/paulbousquet/SmoothLP/main/src)
 ```
 
 ***


### PR DESCRIPTION
Hello,

This PR adds fixes to the installation instructions. Specifically, 'ssc install' does not accept multiple package names. Also, the 'net from' wouldn't work with the current repo structure. I changed it to 'net install' command, but it will not work until other changes are made to the structure of the repo. You can see this repo for reference (but not saying this is the best example... just something that works): https://github.com/SultanOrazbayev/shapley2/tree/main